### PR TITLE
docs: update README and CONTRIBUTING to match current state

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,8 +86,13 @@ oobo is a Rust binary that acts as a transparent git decorator. Key modules:
 | `src/tools/codex.rs` | OpenAI Codex CLI session support |
 | `src/tools/opencode.rs` | OpenCode session support |
 | `src/tools/gemini.rs` | Gemini CLI session support |
+| `src/tools/kiro.rs` | Kiro IDE session support |
+| `src/tools/continue_dev.rs` | Continue session support |
+| `src/tools/droid.rs` | Factory Droid session support |
+| `src/tools/junie.rs` | Junie session support |
+| `src/tools/amp.rs` | Amp session support |
 | `src/core/` | Domain types: anchor, message, session, tool trait |
-| `src/commands/` | CLI subcommands (17 commands) |
+| `src/commands/` | CLI subcommands (23 commands) |
 | `src/analytics/` | Token computation, attribution, git activity |
 | `src/db/` | SQLite persistence and migrations |
 | `src/remote/` | Anchor sync via `/anchors` API (ingest, verify, health) |
@@ -112,11 +117,12 @@ cargo test -- --nocapture
 
 Pull requests run through GitHub Actions:
 
-- `cargo check` on Ubuntu and macOS
-- `cargo test` on Ubuntu and macOS
-- `cargo clippy --all-targets`
+- `cargo check` on Ubuntu
+- `cargo test` on Ubuntu, macOS, and Windows
+- `cargo clippy --all-targets -- -D warnings`
 - `cargo fmt --check`
-- Docker builds on Ubuntu, Debian, and Alpine
+- Security audit via `cargo-audit`
+- Docker builds on Ubuntu, Debian, and Alpine containers
 
 All checks must pass before merge.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ### Git for agents (and humans).
 
-A transparent git decorator that enriches every commit with AI context:<br/>sessions, tokens, and code attribution — across 10 AI coding tools.<br/>No workflow changes. No plugins. No cloud required.
+A transparent git decorator that enriches every commit with AI context:<br/>sessions, tokens, and code attribution — across 15 AI coding tools.<br/>No workflow changes. No plugins. No cloud required.
 
 [![License](https://img.shields.io/badge/license-Apache%202.0%20%2F%20MIT-blue)](LICENSE-APACHE)
 [![CI](https://img.shields.io/github/actions/workflow/status/ooboai/oobo/ci.yml?label=CI)](https://github.com/ooboai/oobo/actions/workflows/ci.yml)
@@ -36,7 +36,7 @@ Or grab a binary from [Releases](https://github.com/ooboai/oobo/releases).
 
 - **Drop-In Git Replacement** — Use `oobo` exactly like `git`. Every command passes through transparently. Read operations have zero overhead.
 - **AI Session Tracking** — Automatically discovers and links AI chat sessions to your commits — which agent wrote what, how many tokens it took, and which conversation produced each change.
-- **10 Tools Supported** — Cursor, Claude Code, Gemini CLI, OpenCode, Codex, Aider, GitHub Copilot, Windsurf, Zed, and Trae.
+- **15 Tools Supported** — Cursor, Claude Code, Gemini CLI, OpenCode, Codex, Aider, GitHub Copilot, Windsurf, Zed, Trae, Amp, Continue, Factory Droid, Junie, and Kiro.
 - **Code Attribution** — Know exactly which lines were AI-generated vs human-written, per commit.
 - **Agent-Native** — Every command supports `--agent` (compact, pipe-delimited) and `--json` (structured) output modes. Built for agents that commit code constantly across tools.
 - **Local-First, Private by Default** — Everything stays in `~/.oobo/`. Nothing leaves your machine unless you opt in. No telemetry. Secrets are redacted before sharing.
@@ -118,10 +118,10 @@ Each anchor records which AI sessions contributed, token counts, code attributio
 | Zed                 | ✓        | ✓           | ✓           | —           |
 | Trae                | ✓        | ✓           | partial     | —           |
 | Amp                 | ✓        | ✓           | —           | —           |
-| Continue            | ✓        | ✓           | —           | —           |
-| Factory Droid       | ✓        | ✓           | —           | —           |
+| Continue            | ✓        | ✓           | —           | ✓           |
+| Factory Droid       | ✓        | ✓           | —           | ✓           |
 | Junie               | ✓        | ✓           | —           | —           |
-| Kiro                | ✓        | ✓           | —           | —           |
+| Kiro                | ✓        | ✓           | —           | ✓           |
 
 All tools are read-only — oobo never writes to AI tool data directories.
 
@@ -160,7 +160,7 @@ Oobo installs a skill file at `~/.oobo/skills/oobo/SKILL.md` during `oobo setup`
 
 ### Agent lifecycle hooks
 
-For tools that support it (Cursor, Claude Code, Gemini CLI, OpenCode), oobo installs hooks that track agent activity in real time: session start/end, tool calls, subagent spawns, thinking events, and context compaction. This enables precise session linking and rich telemetry attached to every commit anchor.
+For tools that support it (Cursor, Claude Code, Gemini CLI, OpenCode, Kiro, Continue, Factory Droid), oobo installs hooks that track agent activity in real time: session start/end, tool calls, subagent spawns, thinking events, and context compaction. This enables precise session linking and rich telemetry attached to every commit anchor.
 
 ---
 
@@ -282,7 +282,7 @@ enabled = true
 enabled = false
 ```
 
-Full list: `cursor`, `claude`, `gemini`, `windsurf`, `aider`, `copilot`, `zed`, `trae`, `codex`, `opencode`.
+Full list: `cursor`, `claude`, `gemini`, `windsurf`, `aider`, `copilot`, `zed`, `trae`, `codex`, `opencode`, `kiro`, `continue`, `droid`, `junie`, `amp`.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes #13

- **README**: Update tool count from 10 → 15 everywhere (tagline, features bullet, config reference) and add the 5 missing tools (Amp, Continue, Factory Droid, Junie, Kiro)
- **README**: Mark Kiro, Continue, and Factory Droid with ✓ in the Agent Hooks column of the supported tools table, and update the agent lifecycle hooks section to list all 7 hooked tools
- **CONTRIBUTING**: Update command count from 17 → 23, add 5 missing tool module entries to the project overview table, and update the CI description to reflect current workflows (Windows testing, security audit, clippy `-D warnings`, Docker containers)

## Test plan

- [x] `cargo check` passes (no Rust code changed — docs only)
- [x] Verify tool count of 15 matches the `registry()` in `src/tools/mod.rs`
- [x] Verify command count of 23 matches the `Command` enum in `src/cli.rs`
- [x] Verify agent hooks list matches `install_all_agent_hooks()` in `src/hooks/install.rs`
- [x] Verify CI description matches `.github/workflows/ci.yml`


Made with [Cursor](https://cursor.com)